### PR TITLE
Fixed pnpm bug that is present in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run `dlp-cli` in DLP's project directory in the terminal
 
 Step 1: If you don't have the `dlp-cli` submodule, run `git submodule init dlp-cli` in the project directory. Then run `git submodule update`. If it says that you are in a detached HEAD state, cd to the dlp-cli submodule directory and `git checkout main`.
 
-Step 2: Run cli in debug mode with `go run main.go`
+Step 2: Run cli in debug mode with `go run main.go`. For example, if you wanted to run the frontend install command in debug mode, run `go run main.go frontend install`.
 
 Step 3: Make sure to add package paths of all files as imports in main.go
 

--- a/cmd/frontend/frontend.go
+++ b/cmd/frontend/frontend.go
@@ -21,7 +21,6 @@ var FrontendCmd = &cobra.Command{
 
 func init() {
 	cmd.RootCmd.AddCommand(FrontendCmd)
-	FrontendCmd.PersistentFlags().Bool("yarn", false, "Uses yarn instead of pnpm")
 }
 
 func ExecBashCmd(name string, args ...string) string {

--- a/cmd/frontend/install/install.go
+++ b/cmd/frontend/install/install.go
@@ -19,11 +19,8 @@ var InstallCmd = &cobra.Command{
 		if cmd.Flag("force").Value.String() == "true" {
 			bash_args = append(bash_args, "--force")
 		}
-		if cmd.Flag("yarn").Value.String() == "true" {
-			frontend.ExecBashCmd("yarn", bash_args...)
-		} else {
-			frontend.ExecBashCmd("pnpm", bash_args...)
-		}
+		frontend.ExecBashCmd("npm" , "install" , "-g" , "pnpm")
+		frontend.ExecBashCmd("pnpm", bash_args...)
 	},
 }
 

--- a/cmd/frontend/start/start.go
+++ b/cmd/frontend/start/start.go
@@ -17,12 +17,7 @@ var StartCmd = &cobra.Command{
 	Long:  `Starts an instance of the nextjs frontend in the terminal`,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if cmd.Flag("yarn").Value.String() == "true" {
-			frontend.ExecBashCmd("yarn", "start", "-p", fmt.Sprintf("%v", cmd.Flag("port").Value))
-		} else {
-			frontend.ExecBashCmd("pnpm", "start", "-p", fmt.Sprintf("%v", cmd.Flag("port").Value))
-		}
-
+		frontend.ExecBashCmd("pnpm", "start", "-p", fmt.Sprintf("%v", cmd.Flag("port").Value))
 	},
 }
 


### PR DESCRIPTION
Changes made:

- Enforced a command that installs pnpm through npm install -g pnpm. This is done in the install.go file
- Cleaned up unused code regarding the use case of yarn in the install.go, start.go, and frontend.go files 
- Updated the Readme for clarity regarding running "go run main.go" in debug mode