### PR TITLE
fixed region for retrieving frontend env secret

### DIFF
--- a/cmd/frontend/build_frontend_env/build-frontend-env-file.go
+++ b/cmd/frontend/build_frontend_env/build-frontend-env-file.go
@@ -13,7 +13,7 @@ import (
     "github.com/spf13/cobra"
     "github.com/DSGT-DLP/Deep-Learning-Playground/cli/cmd/frontend" // For frontend/
     "github.com/DSGT-DLP/Deep-Learning-Playground/cli/utils" // For utils/
-    "encoding/json" // to unmarshal json
+    "encoding/json"
 )
 
 var secretName string // Name of the secret in AWS Secrets Manager
@@ -37,9 +37,9 @@ var buildFrontendEnvCmd = &cobra.Command{
         
         // AWS secrets are parsed from key:value pairs in secrets manager for populating the .env file
 
-        var secretsMap map[string]string // declares a variable of type Map with key:value as string:string
+        var secretsMap map[string]string 
 
-        if err := json.Unmarshal([]byte(*secretValue.SecretString), &secretsMap); err != nil { // stores unmarshalled json into secretsMap
+        if err := json.Unmarshal([]byte(*secretValue.SecretString), &secretsMap); err != nil {
             log.Fatal("error unmarshalling json: ", err)
         } 
         

--- a/cmd/frontend/build_frontend_env/build-frontend-env-file.go
+++ b/cmd/frontend/build_frontend_env/build-frontend-env-file.go
@@ -13,6 +13,7 @@ import (
     "github.com/spf13/cobra"
     "github.com/DSGT-DLP/Deep-Learning-Playground/cli/cmd/frontend" // For frontend/
     "github.com/DSGT-DLP/Deep-Learning-Playground/cli/utils" // For utils/
+    "encoding/json" // to unmarshal json
 )
 
 var secretName string // Name of the secret in AWS Secrets Manager
@@ -33,9 +34,18 @@ var buildFrontendEnvCmd = &cobra.Command{
         }
 
         path := "./frontend"
+        
+        // AWS secrets are parsed from key:value pairs in secrets manager for populating the .env file
 
-        // Adding secrets to the .env file
-        utils.WriteToEnvFile(secretName, *secretValue.SecretString, path)
+        var secretsMap map[string]string // declares a variable of type Map with key:value as string:string
+
+        if err := json.Unmarshal([]byte(*secretValue.SecretString), &secretsMap); err != nil { // stores unmarshalled json into secretsMap
+            log.Fatal("error unmarshalling json: ", err)
+        } 
+        
+        for key,value := range secretsMap {
+            utils.WriteToEnvFile(key, value, path)
+        }
 
         // Hardcoding bucket name as a constant
         utils.WriteToEnvFile("BUCKET_NAME", utils.DlpUploadBucket, path)

--- a/cmd/frontend/frontend.go
+++ b/cmd/frontend/frontend.go
@@ -9,7 +9,7 @@ import (
 )
 
 const FrontendDir string = "./frontend"
-const AwsRegion = "us-west-2"
+const AwsRegion = "us-east-1"
 
 // FrontendCmd represents the frontend command
 var FrontendCmd = &cobra.Command{


### PR DESCRIPTION
Fixed region for retrieving frontend env secret (from us-west-2 to us-east-1).

GitHub issue described [here](https://github.com/DSGT-DLP/dlp-cli/issues/13).

**Process**

1. Changed region in frontend.go file in dlp-cli --> cmd --> frontend from us-west-2 to us-east-1
2. Tested that the build_frontend_env command in dlp-cli works by running `go run main.go frontend build-frontend-env-file --secret "frontend_env"`
3. Encountered error messages detailed and solved in [this link](https://www.notion.so/9b6766cea0b24060bb10d806d58ee0c1?v=1c2cddea700a478a86e95a5e86c09cf8&p=66c7901f9780469ebde4d0cd669dfc87&pm=s).
4. Added fix in build-frontend-env-file to parse through key:value secret values and updated .env file
5. Tested with go script from step 2