### PR TITLE
Update backend start to use docker

### DIFF
--- a/cmd/backend/start/start.go
+++ b/cmd/backend/start/start.go
@@ -4,8 +4,6 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package start
 
 import (
-	"fmt"
-
 	"github.com/DSGT-DLP/Deep-Learning-Playground/cli/cmd/backend"
 	"github.com/spf13/cobra"
 )
@@ -14,15 +12,13 @@ import (
 var StartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Starts the training backend",
-	Long:  `Starts an instance of the training backend Django app in /training in the terminal`,
+	Long:  `Starts an instance of the training backend Django app in /training in the terminal. To change the backend port, set the environment var BACKEND_PORT. `,
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		env_name := cmd.Flag("env-name").Value.String()
-		backend.ExecBashCmd("mamba", "run", "--live-stream", "-n", env_name, "poetry", "run", "python", "manage.py", "runserver", fmt.Sprintf("%v", cmd.Flag("port").Value))
+		backend.ExecBashCmd("docker", "compose", "up", "--build")
 	},
 }
 
 func init() {
 	backend.BackendCmd.AddCommand(StartCmd)
-	StartCmd.PersistentFlags().IntP("port", "p", 8000, "A port to run the backend on")
 }


### PR DESCRIPTION
Because the new training backend relies on starting `celery` and `redis`, I created a docker compose file to start those services in one command, and changed the `backend start` to run docker compose. See https://github.com/DSGT-DLP/Deep-Learning-Playground/pull/1183


https://github.com/DSGT-DLP/dlp-cli/assets/47485510/5fb711a0-bdd9-4355-8ca8-4cfbc547de09

